### PR TITLE
Can break from loop with command

### DIFF
--- a/server/Server.cs
+++ b/server/Server.cs
@@ -115,11 +115,13 @@ namespace server
                 cmd = Console.ReadLine();
                 if (cmd.ToLower() == "uptime")
                 {
-                    Console.WriteLine(stopWatch.Elapsed);
+                    Console.WriteLine("Time since Server started: " + stopWatch.Elapsed);
                 }
+                else if (cmd.ToLower() == "break")
+                { break; }
             };
-            //stopWatch.Stop();
-            //return true;
+            stopWatch.Stop();
+            return true;
         }
     }
 }


### PR DESCRIPTION
**Changes made:**
- In Server class (Server.cs), in listen() method, in while(true) loop, receives command "break" for breaking out the loop. Hence, exiting the application.
